### PR TITLE
Build folder not included because of .gitignore file…

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.idea
+npm-debug.log
+.npmrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runscope-api-wrapper",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "runscope-api-wrapper",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
attempting to get the build folder to show (which is currently missing) because it’s using the .gitignore file:
 
In this case I've added a .npmignore file which has build taken out, so the packager knows to include it. There is more on this here: 

http://stackoverflow.com/questions/31642477/how-to-publish-an-npm-package-with-distribution-files 
https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package