### PR TITLE
problem with node 7.x where gulp cannot find internal/fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runscope-api-wrapper",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "runscope-api-wrapper",
   "main": "build/index.js",
   "scripts": {
@@ -39,6 +39,6 @@
     "request-promise": "^4.1.0"
   },
   "engines": {
-    "node": ">6.3.0"
+    "node": "6.6.0"
   }
 }


### PR DESCRIPTION
problem with node 7.x where gulp cannot find internal/fs, It has been said to downgrade: https://github.com/npm/npm/issues/14232 


Code ship has the error:

module.js:474
throw err;
^

Error: Cannot find module 'internal/fs'
at Function.Module._resolveFilename (module.js:472:15)
at Function.Module._load (module.js:420:25)
at Module.require (module.js:500:17)
at require (internal/module.js:20:19)
at evalmachine.<anonymous>:17:20
at Object.<anonymous> (/home/rof/src/github.com/MaterialDev/runscope-api-wrapper/node_modules/vinyl-fs/node_modules/graceful-fs/fs.js:11:1)
at Module._compile (module.js:573:32)
at Object.Module._extensions..js (module.js:582:10)
at Module.load (module.js:490:32)
at tryModuleLoad (module.js:449:12)
